### PR TITLE
[bazel] Add fixes for --incompatible_load_cc_rules_from_bzl

### DIFF
--- a/bazel-hello/BUILD.bazel
+++ b/bazel-hello/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "hello",
     srcs = ["hello.cc"],

--- a/bazel-hello/WORKSPACE
+++ b/bazel-hello/WORKSPACE
@@ -30,3 +30,14 @@ http_archive(
   strip_prefix = "googletest-8b6d3f9c4a774bef3081195d422993323b6bb2e0",
   sha256 = "d21ba93d7f193a9a0ab80b96e8890d520b25704a6fac976fe9da81fffb3392e3",
 )
+
+# C++ rules for Bazel.
+http_archive(
+    name = "rules_cc",
+    sha256 = "67412176974bfce3f4cf8bdaff39784a72ed709fc58def599d1f68710b58d68b",
+    strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.zip",
+    ],
+)


### PR DESCRIPTION
Starting with Bazel 1.0 (September 2019), C++ rules will need to be
loaded from the @rules_cc repository. This change adds the required
loads for that.

A similar PR was submitted to abseil as abseil/abseil-cpp#351.